### PR TITLE
Fixed a small typo in the data.removeData example

### DIFF
--- a/docs/data/mtscript-data-functions.mdx
+++ b/docs/data/mtscript-data-functions.mdx
@@ -157,7 +157,7 @@ Currently, the only type of data stored is for Add-Ons, but this will be expande
   <br/>
   Example
 
-  ```[r: data.removetData("addon:", "com.example.myaddon", "myVar")]```
+  ```[r: data.removeData("addon:", "com.example.myaddon", "myVar")]```
 
   Things to note:
 


### PR DESCRIPTION
I noticed a small typo in the example for `data.removeData`. 
It has been fixed.